### PR TITLE
added graphene-django to install requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==1.11
 djangorestframework==3.7.7
 pytz==2018.3
 graphene
+graphene-django


### PR DESCRIPTION
Changed requirements.txt due to error which such traceback:
 python manage.py migrate
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/home/majaku/hs-library-back/venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 363, in execute_from_command_line
    utility.execute()
  File "/home/majaku/hs-library-back/venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 337, in execute
    django.setup()
  File "/home/majaku/hs-library-back/venv/lib/python3.6/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/majaku/hs-library-back/venv/lib/python3.6/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/home/majaku/hs-library-back/venv/lib/python3.6/site-packages/django/apps/config.py", line 94, in create
    module = import_module(entry)
  File "/home/majaku/hs-library-back/venv/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'graphene_django'
